### PR TITLE
Make sure allocated string is null terminated.

### DIFF
--- a/bin/tsdfx/scan.c
+++ b/bin/tsdfx/scan.c
@@ -230,6 +230,7 @@ tsdfx_scan_new(const char *path)
 	std->buflen = 0;
 	if ((std->buf = malloc(std->bufsz)) == NULL)
 		goto fail;
+	std->buf[0] = '\0';
 	std->interval = SCAN_INTERVAL; /* XXX should be tunable */
 
 	/* create task and set credentials */


### PR DESCRIPTION
This ensure no unassigned value is used in tsdfx_copy_wrap()
when a scanned directory contain no files.
