### PR TITLE
Check for NULL before derefering.

### DIFF
--- a/bin/tsdfx/copy.c
+++ b/bin/tsdfx/copy.c
@@ -230,10 +230,13 @@ fail:
 static void
 tsdfx_copy_delete(struct tsd_task *t)
 {
-	struct tsdfx_copy_task_data *ctd = t->ud;
+	struct tsdfx_copy_task_data *ctd;
 
 	if (t == NULL)
 		return;
+
+	ctd = t->ud;
+
 	VERBOSE("%s -> %s", ctd->src, ctd->dst);
 	tsdfx_copy_stop(t);
 	tsdfx_copy_remove(t);

--- a/bin/tsdfx/scan.c
+++ b/bin/tsdfx/scan.c
@@ -328,10 +328,13 @@ tsdfx_scan_stop(struct tsd_task *t)
 void
 tsdfx_scan_delete(struct tsd_task *t)
 {
-	struct tsdfx_scan_task_data *std = t->ud;
+	struct tsdfx_scan_task_data *std;
 
 	if (t == NULL)
 		return;
+
+	std = t->ud;
+
 	VERBOSE("%s", std->path);
 	tsdfx_scan_stop(t);
 	tsdfx_scan_remove(t);

--- a/lib/libtsd/tsd_task.c
+++ b/lib/libtsd/tsd_task.c
@@ -102,10 +102,9 @@ tsd_task_create(const char *name, tsd_task_func *func, void *ud)
 void
 tsd_task_destroy(struct tsd_task *t)
 {
-
-	VERBOSE("%s", t->name);
 	if (t == NULL)
 		return;
+	VERBOSE("%s", t->name);
 	if (t->state == TASK_RUNNING)
 		tsd_task_stop(t);
 	if (t->queue != NULL)


### PR DESCRIPTION
Fix ordering errors discovered by cppcheck.
