### PR TITLE
Make log entry about uid/gid 0 more explicit.

### DIFF
--- a/bin/tsdfx/copy.c
+++ b/bin/tsdfx/copy.c
@@ -256,9 +256,9 @@ tsdfx_copy_child(void *ud)
 
 	/* check credentials */
 	if (geteuid() == 0)
-		WARNING("copying %s with uid 0", ctd->src);
+		WARNING("copying %s with uid 0 (file owner missing required privileges?)", ctd->src);
 	if (getegid() == 0)
-		WARNING("copying %s with gid 0", ctd->src);
+		WARNING("copying %s with gid 0 (file owner missing required privileges?)", ctd->src);
 
 	/* set safe umask */
 	umask(TSDFX_COPY_UMASK);


### PR DESCRIPTION
The log messages normally mean the user in question is not allowed
to own files being copyed by tsdfx.
