### PR TITLE
Fix task group handling and improve logging for scan and copy children.

### DIFF
--- a/bin/tsdfx/copy.c
+++ b/bin/tsdfx/copy.c
@@ -255,10 +255,9 @@ tsdfx_copy_child(void *ud)
 	int argc;
 
 	/* check credentials */
-	if (geteuid() == 0)
-		WARNING("copying %s with uid 0", ctd->src);
-	if (getegid() == 0)
-		WARNING("copying %s with gid 0", ctd->src);
+	if (geteuid() == 0 || getegid() == 0)
+		WARNING("copying %s with uid %u gid %u", ctd->src,
+		    (unsigned int)geteuid(), (unsigned int)getegid());
 
 	/* set safe umask */
 	umask(TSDFX_COPY_UMASK);

--- a/bin/tsdfx/scan.c
+++ b/bin/tsdfx/scan.c
@@ -266,10 +266,9 @@ tsdfx_scan_child(void *ud)
 	int argc;
 
 	/* check credentials */
-	if (std->st.st_uid == 0)
-		WARNING("scanning %s with uid 0", std->path);
-	if (std->st.st_gid == 0)
-		WARNING("scanning %s with gid 0", std->path);
+	if (geteuid() == 0 || getegid() == 0)
+		WARNING("scanning %s with uid %u gid %u", std->path,
+		    (unsigned int)geteuid(), (unsigned int)getegid());
 
 	/* change into the target directory, chroot if possible */
 	// XXX chroot code removed, move this into tsd_task_start()

--- a/lib/libtsd/tsd_task.c
+++ b/lib/libtsd/tsd_task.c
@@ -279,13 +279,12 @@ tsd_task_start(struct tsd_task *t)
 
 		/* drop privileges */
 		if (geteuid() == 0 && t->gids[0] > 0 && t->uid != (uid_t)-1) {
-#if HAVE_SETGROUPS
-			ret = setgroups(t->ngids, t->gids);
-#else
-			ret = setgid(t->gids[0]);
-#endif
-			if (ret != 0)
+			if ((ret = setgid(t->gids[0])) != 0)
 				ERROR("failed to set process group");
+#if HAVE_SETGROUPS
+			else if ((ret = setgroups(t->ngids, t->gids)) != 0)
+				ERROR("failed to set additional process groups");
+#endif
 			else if ((ret = setuid(t->uid)) != 0)
 				ERROR("failed to set process user");
 			if (ret != 0)


### PR DESCRIPTION
When setting task child credentials, always call setgid(), even when setgrouplist() is available, as the latter only sets additional group memberships, not the primary group (i.e. what getegid() returns).

In scan and copy tasks, when the euid or egid is zero, always log both.  This makes it easier to track down issues such as files owned by deleted users.
