### PR TITLE
Fix two bugs which may or may not be related to the zombie scan tasks.

### DIFF
--- a/bin/tsdfx/scan.c
+++ b/bin/tsdfx/scan.c
@@ -460,14 +460,7 @@ tsdfx_scan_poll(struct tsd_task *t)
 				if (tsdfx_scan_stop(t) == 0)
 					t->state = TASK_FAILED;
 		}
-		if (pfd.revents & POLLHUP) {
-			if (tsdfx_scan_stop(t) == 0)
-				t->state = TASK_FINISHED;
-		}
-		break;
-	case 0:
-		/* no, process has terminated */
-		if (tsdfx_scan_stop(t) == 0) {
+		if (pfd.revents & POLLHUP && tsdfx_scan_stop(t) == 0) {
 			/* validate */
 			if (regexec(&scan_regex, std->buf, 0, NULL, 0) != 0) {
 				WARNING("invalid output from child %ld for %s",
@@ -477,6 +470,9 @@ tsdfx_scan_poll(struct tsd_task *t)
 				t->state = TASK_FINISHED;
 			}
 		}
+		break;
+	case 0:
+		/* no input for now */
 		break;
 	default:
 		/* oops */

--- a/lib/libtsd/tsd_task.c
+++ b/lib/libtsd/tsd_task.c
@@ -335,7 +335,7 @@ fail:
 int
 tsd_task_stop(struct tsd_task *t)
 {
-	static const int sig[] = { SIGCONT, SIGTERM, SIGKILL, -1 };
+	static const int sig[] = { SIGCONT, SIGTERM, SIGKILL, 0, -1 };
 	int i, serrno;
 
 	VERBOSE("%s", t->name);
@@ -351,9 +351,7 @@ tsd_task_stop(struct tsd_task *t)
 		if (t->state != TASK_STOPPING)
 			break;
 		/* not dead yet; kill, wait 100 ms and retry */
-		if (sig[i])
-			kill(t->pid, sig[i]);
-		if (kill(t->pid, SIGCONT) != 0) {
+		if (kill(t->pid, sig[i]) != 0) {
 			serrno = errno;
 			WARNING("unable to signal child %d", (int)t->pid);
 			tsd_task_close(t, TASK_DEAD);


### PR DESCRIPTION
First, in tsdfx_scan_poll(), don't kill the scan task if poll(2) returns 0; all it means is that the scanner is working and there is no output waiting for us.

Second, in tsd_task_stop(), add a 0 to the list of signals to send to the child to ensure that we call tsd_task_poll() (and thus waitpid(2)) after sending SIGKILL, instead of immediately giving up.
