### PR TITLE
Change logging to use syslog by default, while file logging is an option

### DIFF
--- a/bin/tsdfx/copy.c
+++ b/bin/tsdfx/copy.c
@@ -251,7 +251,7 @@ static void
 tsdfx_copy_child(void *ud)
 {
 	struct tsdfx_copy_task_data *ctd = ud;
-	const char *argv[6];
+	const char *argv[8];
 	int argc;
 
 	/* check credentials */
@@ -269,6 +269,8 @@ tsdfx_copy_child(void *ud)
 		argv[argc++] = "-n";
 	if (tsdfx_verbose)
 		argv[argc++] = "-v";
+	argv[argc++] = "-l";
+	argv[argc++] = tsd_log_getname();
 	argv[argc++] = ctd->src;
 	argv[argc++] = ctd->dst;
 	argv[argc] = NULL;

--- a/bin/tsdfx/main.c
+++ b/bin/tsdfx/main.c
@@ -52,7 +52,8 @@ static void
 usage(void)
 {
 
-	fprintf(stderr, "usage: tsdfx [-1nv] [-C copier] [-S scanner] -m mapfile\n");
+	fprintf(stderr, "usage: tsdfx [-1nv] "
+	    "[-l logname] [-C copier] [-S scanner] -m mapfile\n");
 	exit(1);
 }
 
@@ -60,14 +61,14 @@ static void
 showversion(void)
 {
 	fprintf(stderr, "%s\n\nReport bugs to %s and visit\n%s to learn more.\n\n",
-		PACKAGE_STRING, PACKAGE_BUGREPORT, PACKAGE_URL);
+	    PACKAGE_STRING, PACKAGE_BUGREPORT, PACKAGE_URL);
 	exit(1);
 }
 
 int
 main(int argc, char *argv[])
 {
-	const char *mapfile;
+	const char *logfile, *mapfile;
 	int opt;
 
 #if HAVE_SETPROCTITLE_INIT
@@ -78,13 +79,16 @@ main(int argc, char *argv[])
 #endif
 
 	mapfile = NULL;
-	while ((opt = getopt(argc, argv, "1C:hm:nS:vV")) != -1)
+	while ((opt = getopt(argc, argv, "1C:hl:m:nS:vV")) != -1)
 		switch (opt) {
 		case '1':
 			++tsdfx_oneshot;
 			break;
 		case 'C':
 			tsdfx_copier = optarg;
+			break;
+		case 'l':
+			logfile = optarg;
 			break;
 		case 'm':
 			mapfile = optarg;
@@ -124,7 +128,7 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
-	if (tsd_log_init() != 0)
+	if (tsd_log_init("tsdfx", logfile) != 0)
 		exit(1);
 	if (tsdfx_init(mapfile) != 0)
 		exit(1);

--- a/bin/tsdfx/scan.c
+++ b/bin/tsdfx/scan.c
@@ -262,7 +262,7 @@ static void
 tsdfx_scan_child(void *ud)
 {
 	struct tsdfx_scan_task_data *std = ud;
-	const char *argv[4];
+	const char *argv[6];
 	int argc;
 
 	/* check credentials */
@@ -282,6 +282,8 @@ tsdfx_scan_child(void *ud)
 	argv[argc++] = tsdfx_scanner;
 	if (tsdfx_verbose)
 		argv[argc++] = "-v";
+	argv[argc++] = "-l";
+	argv[argc++] = tsd_log_getname();
 	argv[argc++] = ".";
 	argv[argc] = NULL;
 	/* XXX should clean the environment */

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
 AC_PREREQ([2.64])
-AC_INIT([TSD File eXchange], [1.20150421], [d.e.smorgrav@usit.uio.no], [tsdfx], [http://www.uio.no/tjenester/it/forskning/sensitiv/])
+AC_INIT([TSD File eXchange], [1.20151007], [d.e.smorgrav@usit.uio.no],
+    [tsdfx], [https://www.github.com/unioslo/tsdfx])
 AC_CONFIG_SRCDIR([bin/tsdfx/tsdfx.c])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign])
@@ -30,6 +31,7 @@ AC_CHECK_FUNCS([strlcat strlcpy])
 AC_CHECK_FUNCS([closefrom fpurge])
 AC_CHECK_FUNCS([statvfs])
 AC_CHECK_FUNCS([getgroups setgroups initgroups])
+AC_CHECK_FUNCS([vasprintf])
 
 # setproctitle
 AC_CHECK_HEADERS([bsd/stdlib.h bsd/unistd.h])

--- a/include/tsd/log.h
+++ b/include/tsd/log.h
@@ -30,36 +30,42 @@
 #ifndef TSD_LOG_H_INCLUDED
 #define TSD_LOG_H_INCLUDED
 
-void tsd_log(const char *, int, const char *, const char *, ...);
-int tsd_log_init(void);
+typedef enum {
+	TSD_LOG_LEVEL_VERBOSE,
+	TSD_LOG_LEVEL_NOTICE,
+	TSD_LOG_LEVEL_WARNING,
+	TSD_LOG_LEVEL_ERROR,
+} tsd_log_level_t;
+
+void tsd_log(tsd_log_level_t, const char *, int, const char *, const char *, ...);
+int tsd_log_init(const char *, const char *);
+const char *tsd_log_getname(void);
 
 extern int tsd_log_quiet;
 extern int tsd_log_verbose;
 
 #define VERBOSE(...) \
 	do {								\
-		if (tsd_log_verbose)					\
-			tsd_log(__FILE__, __LINE__, __func__,		\
-			    __VA_ARGS__);				\
+		tsd_log(TSD_LOG_LEVEL_VERBOSE, __FILE__,		\
+			__LINE__, __func__, __VA_ARGS__);		\
 	} while (0)
 
 #define NOTICE(...) \
 	do {								\
-		if (!tsd_log_quiet)					\
-			tsd_log(__FILE__, __LINE__, __func__,		\
-			    __VA_ARGS__);				\
+		tsd_log(TSD_LOG_LEVEL_NOTICE, __FILE__, __LINE__,	\
+			__func__,__VA_ARGS__);				\
 	} while (0)
 
 #define WARNING(...) \
 	do {								\
-		tsd_log(__FILE__, __LINE__, __func__,			\
-		    __VA_ARGS__);					\
+		tsd_log(TSD_LOG_LEVEL_WARNING, __FILE__, __LINE__,	\
+			__func__, __VA_ARGS__);				\
 	} while (0)
 
 #define ERROR(...) \
 	do {								\
-		tsd_log(__FILE__, __LINE__, __func__,			\
-		    __VA_ARGS__);					\
+		tsd_log(TSD_LOG_LEVEL_ERROR, __FILE__, __LINE__,	\
+			__func__, __VA_ARGS__);				\
 	} while (0)
 
 #endif

--- a/libexec/copier/copier.c
+++ b/libexec/copier/copier.c
@@ -536,23 +536,23 @@ static void
 usage(void)
 {
 
-	fprintf(stderr, "usage: tsdfx-copier [-nv] src dst\n");
+	fprintf(stderr, "usage: tsdfx-copier [-nv] [-l logname] src dst\n");
 	exit(1);
 }
 
 int
 main(int argc, char *argv[])
 {
+	const char *logfile;
 	int opt;
 
-	tsd_log_init();
-	if (getuid() == 0 || geteuid() == 0)
-		WARNING("running as root");
-
-	while ((opt = getopt(argc, argv, "fhnv")) != -1)
+	while ((opt = getopt(argc, argv, "fhl:nv")) != -1)
 		switch (opt) {
 		case 'f':
 			++tsdfx_force;
+			break;
+		case 'l':
+			logfile = optarg;
 			break;
 		case 'n':
 			++tsdfx_dryrun;
@@ -569,6 +569,11 @@ main(int argc, char *argv[])
 
 	if (argc != 2)
 		usage();
+
+	tsd_log_init("tsdfx-copier", logfile);
+
+	if (getuid() == 0 || geteuid() == 0)
+		WARNING("running as root");
 
 	if (tsdfx_copier(argv[0], argv[1]) != 0)
 		exit(1);

--- a/libexec/scanner/scanner.c
+++ b/libexec/scanner/scanner.c
@@ -300,21 +300,21 @@ static void
 usage(void)
 {
 
-	fprintf(stderr, "usage: tsdfx-scanner [-v] path\n");
+	fprintf(stderr, "usage: tsdfx-scanner [-v] [-l logname] path\n");
 	exit(1);
 }
 
 int
 main(int argc, char *argv[])
 {
+	const char *logfile;
 	int opt;
 
-	tsd_log_init();
-	if (getuid() == 0 || geteuid() == 0)
-		WARNING("running as root");
-
-	while ((opt = getopt(argc, argv, "hv")) != -1)
+	while ((opt = getopt(argc, argv, "hl:v")) != -1)
 		switch (opt) {
+		case 'l':
+			logfile = optarg;
+			break;
 		case 'v':
 			++tsd_log_verbose;
 			break;
@@ -327,6 +327,11 @@ main(int argc, char *argv[])
 
 	if (argc != 1)
 		usage();
+
+	tsd_log_init("tsdfx-scanner", logfile);
+
+	if (getuid() == 0 || geteuid() == 0)
+		WARNING("running as root");
 
 	if (tsdfx_scanner(argv[0]) != 0)
 		exit(1);

--- a/t/test.sh.in
+++ b/t/test.sh.in
@@ -2,7 +2,7 @@
 
 x() {
 	echo "$@"
-	"$@" > "${logfile}" 2>&1
+	"$@"
 }
 
 fail() {
@@ -51,7 +51,7 @@ dd bs=1k count=${randomsize} \
 md5start=$(cd ${srcdir}; md5sum ${randomsize}krandom)
 
 echo "logging to ${logfile}"
-x "${tsdfx}" -m "${mapfile}" -1v
+x "${tsdfx}" -l "${logfile}" -m "${mapfile}" -1v
 
 for good in test1 test2 ; do
 	if [ ! -e "${dstdir}/${good}" ] ; then


### PR DESCRIPTION
Change the log API to include the severity in the tsd_log() call and
move logic deciding when to log / print into that function.  Change
logging to log to syslog by default, and provide a new -l option to log
to a file or stderr/stdout.

Based on syslog related patches from abdulrahmanazab, and with improvements
from dag-erling.

This solves issue #20.
