### PR TITLE
Initialize logfile to NULL

### DIFF
--- a/bin/tsdfx/main.c
+++ b/bin/tsdfx/main.c
@@ -86,7 +86,7 @@ main(int argc, char *argv[])
 	setproctitle("master");
 #endif
 
-	mapfile = NULL;
+	logfile = mapfile = NULL;
 	pidfilename = PIDFILENAME;
 	while ((opt = getopt(argc, argv, "1C:hl:m:np:S:vV")) != -1)
 		switch (opt) {

--- a/libexec/copier/copier.c
+++ b/libexec/copier/copier.c
@@ -553,6 +553,7 @@ main(int argc, char *argv[])
 	const char *logfile;
 	int opt;
 
+	logfile = NULL;
 	while ((opt = getopt(argc, argv, "fhl:nv")) != -1)
 		switch (opt) {
 		case 'f':

--- a/libexec/scanner/scanner.c
+++ b/libexec/scanner/scanner.c
@@ -310,6 +310,7 @@ main(int argc, char *argv[])
 	const char *logfile;
 	int opt;
 
+	logfile = NULL;
 	while ((opt = getopt(argc, argv, "hl:v")) != -1)
 		switch (opt) {
 		case 'l':


### PR DESCRIPTION
Initialize logfile to NULL so we don't pass garbage to tsd_log_init() if no log file was specified on the command line.
