### PR TITLE
Fix scanner child exit code.

### DIFF
--- a/libexec/scanner/scanner.c
+++ b/libexec/scanner/scanner.c
@@ -242,13 +242,14 @@ tsdfx_scan_process_directory(const struct sbuf *path)
 {
 	DIR *dir;
 	struct dirent *de;
-	int dd, serrno;
+	int dd, ret, serrno;
 
+	ret = 0;
 	if ((dd = open(sbuf_data(path), O_RDONLY)) < 0)
 		return (-1);
 	if ((dir = fdopendir(dd)) == NULL)
 		return (-1);
-	while ((de = readdir(dir)) != NULL) {
+	while (ret == 0 && (de = readdir(dir)) != NULL) {
 		if (strcmp(de->d_name, ".") == 0 ||
 		    strcmp(de->d_name, "..") == 0)
 			continue;
@@ -259,11 +260,12 @@ tsdfx_scan_process_directory(const struct sbuf *path)
 			continue;
 		}
 		if (tsdfx_process_dirent(path, dd, de) != 0)
-			break;
+			ret = -1;
 	}
 	serrno = errno;
 	closedir(dir);
-	return ((errno = serrno) ? -1 : 0);
+	errno = serrno;
+	return (ret);
 }
 
 /*


### PR DESCRIPTION
The main loop in the scanner relied on errno alone to detect that an error had occurred.  However, the value of errno after a successful system call is usually _undefined_, not zero.  The consequence is that the scanner sometimes returned a non-zero exit code after a successful run, and the output from that run was ignored.  This seems to be more likely to happen if the scanner encounters a file with an invalid name, which is why the \002 test would sometimes fail and sometimes not.
