### PR TITLE
Conditional seek hole

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,11 @@ AC_CHECK_HEADERS([bsd/stdlib.h bsd/unistd.h])
 AC_SEARCH_LIBS([setproctitle], [bsd])
 AC_CHECK_FUNCS([setproctitle_init setproctitle])
 
+# hole detection
+AC_CHECK_DECLS([SEEK_HOLE])
+AM_CONDITIONAL([WITH_HOLE_DETECTION],
+  [test x"$ac_cv_have_decl_SEEK_HOLE" = x"yes"])
+
 # options
 AC_ARG_ENABLE([debug],
     AC_HELP_STRING([--enable-debug], [turn debugging macros on (default is NO)]),

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,3 +1,7 @@
 EXTRA_DIST = test-simplecopy.sh test-file-hole.sh pidfile.sh testsuite-common.sh
 
-TESTS = test-simplecopy.sh test-file-hole.sh pidfile.sh
+TESTS = test-simplecopy.sh pidfile.sh
+
+if WITH_HOLE_DETECTION
+TESTS +=  test-file-hole.sh
+endif

--- a/t/test-file-hole.sh
+++ b/t/test-file-hole.sh
@@ -19,6 +19,7 @@ write_holy_file() {
 }
 
 setup_test
+set_blocksize
 
 write_holy_file "${srcdir}/${randomsize}krandom-with-holes" &
 

--- a/t/testsuite-common.sh.in
+++ b/t/testsuite-common.sh.in
@@ -9,6 +9,10 @@ x() {
 	"$@"
 }
 
+notice() {
+	echo "NOTICE $@" >&2
+}
+
 fail() {
 	(
 		echo "FAIL $@"
@@ -21,11 +25,6 @@ fail() {
 }
 
 setup_test() {
-	blocksize=$(stat -f%k . || stat -c%o .) 2>/dev/null
-	expr "${blocksize}" : '^[1-9][0-9]*$' >/dev/null || \
-	    fail "Unable to determine filesystem block size"
-	echo "Using ${blocksize}-byte blocks"
-
 	set -e
 
 	tstdir="@abs_builddir@/t$$"
@@ -46,6 +45,32 @@ setup_test() {
 	cat >"${mapfile}" <<EOF
 test: ${srcdir} => ${dstdir}
 EOF
+}
+
+set_blocksize() {
+	local bsfile bs
+	if [ -f "$1" ] ; then
+		bsfile="$1"
+	else
+		if [ -z "$1" ] ; then
+			bsfile="${tstdir}/bsfile"
+		elif [ -d "$1" ] ; then
+			bsfile="$1/bsfile"
+		else
+			fail "can't determine block size of $1"
+		fi
+		dd if=/dev/zero of="${bsfile}" bs=1048576 count=1
+	fi
+	blocksize=$(
+		stat -f%k "${bsfile}"  2>/dev/null ||
+		stat -c%o "${bsfile}" 2>/dev/null
+	)
+	if [ "${bsfile}" != "$1" ] ; then
+		rm "${bsfile}"
+	fi
+	expr "${blocksize}" : '^[1-9][0-9]*$' >/dev/null || \
+	    fail "Unable to determine filesystem block size"
+	notice "Using ${blocksize}-byte blocks"
 }
 
 run_daemon() {


### PR DESCRIPTION
Check for SEEK_HOLE in configure.ac and don't try to run the file hole test if it's not available.
Fix block size detection so the file hole test will work on platforms with different block sizes for directories and files (e.g. ZFS).
