### PR TITLE
Make pidfile test more robust.

### DIFF
--- a/t/pidfile.sh
+++ b/t/pidfile.sh
@@ -11,12 +11,19 @@ pidfile="${tstdir}/tsdfx.pid"
 echo "logging to ${logfile}"
 x "${tsdfx}" -l "${logfile}" -p "${pidfile}" -m "${mapfile}" -v &
 pid=$!
-sleep 2
+
+# wait a while for the pid file to show up
+limit=20
+while [ ! -f "${pidfile}" ] && [ 0 -ne "$limit" ] ; do
+    sleep 1
+    limit=$(($limit - 1))
+done
 
 if [ -f "${pidfile}" ]; then
-    echo "success: found pid file ${pidfile}"
+    waittime=$((20 - $limit))
+    echo "success: found pid file ${pidfile} (took $waittime seconds)"
 else
-    fail "missing pid file ${pidfile}"
+    fail "missing pid file ${pidfile} (gave up after 20 seconds)"
 fi
 
 kill "$(cat ${pidfile})"


### PR DESCRIPTION
The pidfile test assumed the pidfile would show up after 2 seconds.
This did not happen on a busy machine.  Rewrite the test to wait longer,
and continue right away when the pid file show up.
