### PR TITLE
Have separate copy task queues for small and large files.

### DIFF
--- a/bin/tsdfx/tsdfx_copy.h
+++ b/bin/tsdfx/tsdfx_copy.h
@@ -32,7 +32,7 @@
 
 struct tsd_task;
 
-struct tsd_task *tsdfx_copy_new(const char *, const char *);
+struct tsd_task *tsdfx_copy_new(const char *, const char *, long int);
 
 int tsdfx_copy_sched(void);
 int tsdfx_copy_init(void);

--- a/libexec/copier/tsdfx-copier.8
+++ b/libexec/copier/tsdfx-copier.8
@@ -36,6 +36,7 @@
 .Nm
 .Op Fl fnv
 .Op Fl l logname
+.Op Fl m maxsize
 .Ar Pa src
 .Ar Pa dst
 .Sh DESCRIPTION

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,5 +1,6 @@
 EXTRA_DIST = \
 	pidfile.sh \
+	test-copy-classes.sh \
 	test-file-hole.sh \
 	test-inaccessible-dir.sh \
 	test-simplecopy.sh \
@@ -7,6 +8,7 @@ EXTRA_DIST = \
 
 TESTS = \
 	pidfile.sh \
+	test-copy-classes.sh \
 	test-file-hole.sh \
 	test-inaccessible-dir.sh \
 	test-simplecopy.sh

--- a/t/test-copy-classes.sh
+++ b/t/test-copy-classes.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+# Check that small files are copied by small file copiers.
+
+. $(dirname $0)/testsuite-common.sh
+
+setup_test
+
+limit=$((1024*1024))
+
+echo test1 > "${srcdir}/smallfile"
+
+dd bs=$limit count=1 \
+    if=/dev/urandom \
+    of="${srcdir}/borderfile" > /dev/null 2>&1
+
+dd bs=$((2 * $limit)) count=1 \
+    if=/dev/urandom \
+    of="${srcdir}/largefile" > /dev/null 2>&1
+
+run_daemon
+
+for good in smallfile largefile borderfile; do
+	if [ ! -e "${dstdir}/${good}" ] ; then
+		fail "missing: ${dstdir}/${good}"
+	elif ! cmp -s "${srcdir}/${good}" "${dstdir}/${good}" ; then
+		fail "incorrect: ${dstdir}/${good}"
+	fi
+done
+
+if egrep -q "Assigning .*/smallfile to copier for files size<$limit" ${logfile}; then
+    notice "Correctly assigned smallfile to small file copier."
+else
+    fail "Did not find copier assignment for smallfile in the log."
+fi
+
+if egrep -q 'Assigning .*/borderfile to copier for files size<-1' ${logfile}; then
+    notice "Correctly assigned borderfile to large file copier"
+else
+    fail "Did not find copier assignment for borderfile in the log."
+fi
+
+if egrep -q 'Assigning .*/largefile to copier for files size<-1' ${logfile}; then
+    notice "Correctly assigned largefile to large file copier"
+else
+    fail "Did not find copier assignment for largefile in the log."
+fi
+
+cleanup_test


### PR DESCRIPTION
Rewrite copy task handling to use tsd_tqueue, and provide two queues, one with 2
members for small files, and one with 8 members for large files.  Files larger
than 1 MiB are large files.
