### PR TITLE
Clean up the copier.

### DIFF
--- a/t/test-file-hole.sh
+++ b/t/test-file-hole.sh
@@ -10,10 +10,10 @@ write_holy_file() {
 	if=/dev/urandom of="$filename" > /dev/null 2>&1
     dd bs=${blocksize} seek=3 count=1 conv=notrunc \
 	if=/dev/urandom of="$filename" > /dev/null 2>&1
-    sleep 5
+    sleep 3
     dd bs=${blocksize} seek=0 count=1 conv=notrunc \
 	if=/dev/urandom of="$filename" > /dev/null 2>&1
-    sleep 5
+    sleep 3
     dd bs=${blocksize} seek=2 count=1 conv=notrunc \
 	if=/dev/urandom of="$filename" > /dev/null 2>&1
 }


### PR DESCRIPTION
- Remove the SEEK_HOLE code since we know that it will never work reliably.
- Remove the delay at EOF as the new backoff logic should take care of it.  This makes an enormous difference when copying small files, because instead of waiting ten seconds after copying the file, we only wait until the file is at least ten seconds old.
- Reduce the end-of-file delay from ten seconds to six.
- Fix a VERBOSE message which always printed garbage due to integer promotion.
