### PR TITLE
Interleave scanning and copying.

### DIFF
--- a/bin/tsdfx/tsdfx_map.h
+++ b/bin/tsdfx/tsdfx_map.h
@@ -30,9 +30,10 @@
 #ifndef TSDFX_MAP_H_INCLUDED
 #define TSDFX_MAP_H_INCLUDED
 
-struct map;
+struct tsdfx_map;
 
 int tsdfx_map_reload(const char *);
+int tsdfx_map_process(struct tsdfx_map *, const char *);
 int tsdfx_map_sched(void);
 int tsdfx_map_exit(void);
 

--- a/bin/tsdfx/tsdfx_scan.h
+++ b/bin/tsdfx/tsdfx_scan.h
@@ -32,7 +32,7 @@
 
 struct tsd_task;
 
-struct tsd_task *tsdfx_scan_new(const char *);
+struct tsd_task *tsdfx_scan_new(struct tsdfx_map *, const char *);
 void tsdfx_scan_delete(struct tsd_task *);
 int tsdfx_scan_reset(struct tsd_task *);
 


### PR DESCRIPTION
Instead of waiting for the scanner to finish before validating its output and creating copy tasks, process it little by little.  This avoids tying up the master process when scanning very large directories.
