### PR TITLE
Fix the scanner buffer boundary bug.

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -3,6 +3,7 @@ EXTRA_DIST = \
 	test-copy-classes.sh \
 	test-file-hole.sh \
 	test-inaccessible-dir.sh \
+	test-scanner-boundary.sh \
 	test-simplecopy.sh \
 	testsuite-common.sh
 
@@ -11,4 +12,5 @@ TESTS = \
 	test-copy-classes.sh \
 	test-file-hole.sh \
 	test-inaccessible-dir.sh \
+	test-scanner-boundary.sh \
 	test-simplecopy.sh

--- a/t/test-scanner-boundary.sh
+++ b/t/test-scanner-boundary.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# Regression test for a bug in tsdfx_scan_slurp() where, instead of
+# retaining incomplete data at the end of a buffer and appending new
+# data after it, it simply discards whatever is left.
+#
+
+. $(dirname $0)/testsuite-common.sh
+
+setup_test
+
+# content
+content="the quick brown fox jumps over the squeamish ossifrage"
+content_md5=$(echo $content | md5sum)
+
+# number of files required to trigger the bug
+bufsize=$(awk '/^#define.*SCAN_BUFFER_SIZE/ { print $3 }' ${source}/bin/tsdfx/scan.c)
+digits=64
+linelen=$((digits + 2))
+linesperbuf=$((bufsize / linelen))
+minfiles=$((linesperbuf))
+maxfiles=$((linesperbuf + 5))
+
+# filenames
+list=${tstdir}/scanner-boundary-files
+for n in $(seq 1 $maxfiles) ; do
+	printf "/%0${digits}d\n" $n
+done >> ${list}
+
+while read fn ; do
+	echo $content >${srcdir}${fn}
+done < ${list}
+
+run_daemon
+
+missing=0
+invalid=0
+while read fn ; do
+	if [ ! -f ${dstdir}${fn} ] ; then
+		notice "missing: ${fn}"
+		: $((missing++))
+	elif [ $(md5sum ${dstdir}${fn}) != $content_md5 ] ; then
+		notice "invalid contents: ${fn}"
+		: $((invalid++))
+	fi
+done < ${list}
+
+if [ $missing -gt 0 -o $invalid -gt 0 ] ; then
+	fail "$missing missing, $invalid invalid"
+fi
+
+cleanup_test

--- a/t/testsuite-common.sh.in
+++ b/t/testsuite-common.sh.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 md5sum() {
-	openssl md5 -r "$@"
+	openssl md5 -r "$@" | cut -d' ' -f1
 }
 
 x() {
@@ -33,6 +33,8 @@ fail() {
 
 setup_test() {
 	set -e
+
+	source="@abs_top_srcdir@"
 
 	tstdir="@abs_builddir@/t$$"
 	logfile="${tstdir}/log"


### PR DESCRIPTION
When data is left over at the end of `tsdfx_scan_slurp()`, we need to move it to the beginning of the buffer so we have room to append more data in the next iteration.  Instead of copying from `p`, which is the start of the last (incomplete) line in the buffer, we were copying from `q`, which is the end of the buffer.  The symptom of this bug was that every time the scanner's output crossed a buffer boundary, we would try to process a file name which was missing its first few characters.

Additionally, poll() will set both `POLLIN` and `POLLHUP` if all remaining output from the child is buffered in the kernel, but there may still be data left over after `tsdfx_scan_slurp()`.  Therefore, ignore `POLLHUP` unless it comes alone, i.e. there is no data left in the kernel buffer.  The symptom of this bug was that we would silently drop the last few lines of the scanner's output; the exact amount is not easily predictable, as it depends on several factors including the length of the output, the rate at which it is emitted, and the size of the kernel buffer, both in absolute terms and relative to the size of our own buffer.

Finally, and mostly for cleanliness's sake (since it isn't used anywhere), give `tsdfx_scan_slurp()` a well-defined return value in the non-error case.
