### PR TITLE
Correctly reset scan tasks

### DIFF
--- a/bin/tsdfx/scan.c
+++ b/bin/tsdfx/scan.c
@@ -595,18 +595,18 @@ tsdfx_scan_sched(void)
 			tsdfx_scan_poll(t);
 			break;
 		case TASK_FINISHED:
-			tsd_task_reset(t);
+			tsdfx_scan_reset(t);
 			break;
 		case TASK_DEAD:
 		case TASK_FAILED:
 		case TASK_INVALID:
 			if (now >= std->lastran + tsdfx_reset_interval)
-				tsd_task_reset(t);
+				tsdfx_scan_reset(t);
 			break;
 		case TASK_STOPPED:
 			/* shouldn't happen */
 			ERROR("scan task in TASK_STOPPED state");
-			tsd_task_reset(t);
+			tsdfx_scan_reset(t);
 			break;
 		default:
 			/* unreachable */


### PR DESCRIPTION
tsdfx_scan_sched() used tsd_task_reset() instead of tsdfx_scan_reset() to reset scan tasks.  The latter is a wrapper around the former which also performs some sanity checks and schedules the next run.  Without it, scan tasks would run continuously rather than periodically, and would not be cancelled if the target directory disappeared.
