### PR TITLE
Clean up the tests a little

### DIFF
--- a/t/test-copy-classes.sh
+++ b/t/test-copy-classes.sh
@@ -28,9 +28,9 @@ run_daemon -1
 
 while read name size ; do
 	if [ ! -e "${dstdir}/${name}" ] ; then
-		fail "missing: ${dstdir}/${name}"
+		fail_test "missing: ${dstdir}/${name}"
 	elif ! cmp -s "${srcdir}/${name}" "${dstdir}/${name}" ; then
-		fail "incorrect: ${dstdir}/${name}"
+		fail_test "incorrect: ${dstdir}/${name}"
 	fi
 	if [ "${size}" -le "${limit}" ] ; then
 		class="${limit}"
@@ -40,9 +40,9 @@ while read name size ; do
 	if egrep -q "Assigning .*/${name} .* <= ${class}" "${logfile}" ; then
 		notice "${name} was assigned to the correct copier"
 	elif egrep -q "Assigning .*/${name} .* <= [0-9]+" "${logfile}" ; then
-		fail "${name} was assigned to the wrong copier"
+		fail_test "${name} was assigned to the wrong copier"
 	else
-		fail "unable to find copier assignment for ${name}"
+		fail_test "unable to find copier assignment for ${name}"
 	fi
 done < "${casefile}"
 

--- a/t/test-file-hole.sh
+++ b/t/test-file-hole.sh
@@ -28,7 +28,7 @@ run_daemon -1
 hmd5src="$(cd "${srcdir}"; md5sum "random-with-holes")"
 hmd5dst="$(cd "${dstdir}"; md5sum "random-with-holes")"
 if [ "$hmd5src" != "$hmd5dst" ] ; then
-    fail "File with hole changed MD5sum during transmission: $hmd5src != $hmd5dst"
+    fail_test "File with hole changed MD5sum during transmission: $hmd5src != $hmd5dst"
 else
     echo "All ok with holy file"
 fi

--- a/t/test-inaccessible-dir.sh
+++ b/t/test-inaccessible-dir.sh
@@ -25,9 +25,9 @@ run_daemon -1
 # inaccessible directory
 for good in test2; do
 	if [ ! -e "${dstdir}/${good}" ] ; then
-		fail "missing: ${dstdir}/${good}"
+		fail_test "missing: ${dstdir}/${good}"
 	elif ! cmp -s "${srcdir}/${good}" "${dstdir}/${good}" ; then
-		fail "incorrect: ${dstdir}/${good}"
+		fail_test "incorrect: ${dstdir}/${good}"
 	fi
 done
 

--- a/t/test-map-corruption.sh
+++ b/t/test-map-corruption.sh
@@ -13,14 +13,14 @@ timeout=10
 elapsed=0
 while ! grep -q tsdfx_scan_stop "${logfile}" ; do
 	[ $((elapsed+=1)) -le "${timeout}" ] ||
-		fail "timed out waiting for first scan"
+		fail_test "timed out waiting for first scan"
 	sleep 1
 done
 notice "initial scan complete after ${elapsed} seconds"
 scan_stop_count=$(grep -c tsdfx_scan_stop "${logfile}")
 
 if grep -q 'tsdfx_map_reload.*keeping' "${logfile}" ; then
-	fail "map file spontaneously reloaded"
+	fail_test "map file spontaneously reloaded"
 fi
 
 echo "the quick brown fox jumps over the lazy dog" >"${srcdir}/test1"
@@ -32,7 +32,7 @@ kill -HUP $(cat "${pidfile}")
 elapsed=0
 while ! grep -q 'tsdfx_map_reload.*keeping' "${logfile}" ; do
 	[ $((elapsed+=1)) -le "${timeout}" ] ||
-		fail "timed out waiting for map reload"
+		fail_test "timed out waiting for map reload"
 	sleep 1
 done
 notice "map reloaded after ${elapsed} seconds"
@@ -41,7 +41,7 @@ notice "map reloaded after ${elapsed} seconds"
 elapsed=0
 while ! [ -s "${dstdir}/test1" -a -s "${dstdir}/test2" ] ; do
 	[ $((elapsed+=1)) -le "${timeout}" ] ||
-		fail "timed out waiting for copy"
+		fail_test "timed out waiting for copy"
 	sleep 1
 done
 notice "copy complete after ${elapsed} seconds"
@@ -49,9 +49,9 @@ notice "copy complete after ${elapsed} seconds"
 # Compare source and destination
 for good in test1 test2 ; do
 	if [ ! -e "${dstdir}/${good}" ] ; then
-		fail "missing: ${dstdir}/${good}"
+		fail_test "missing: ${dstdir}/${good}"
 	elif ! cmp -s "${srcdir}/${good}" "${dstdir}/${good}" ; then
-		fail "incorrect: ${dstdir}/${good}"
+		fail_test "incorrect: ${dstdir}/${good}"
 	fi
 done
 

--- a/t/test-pidfile.sh
+++ b/t/test-pidfile.sh
@@ -6,10 +6,13 @@ setup_test
 
 run_daemon
 
+# Timeout for various operations
+timeout=10
+
 # wait for the pid file to appear
-limit=20
+elapsed=0
 while [ ! -s "${pidfile}" ] ; do
-	[ $((elapsed+=1)) -lt $limit ] ||
+	[ $((elapsed+=1)) -le "${timeout}" ] ||
 		fail "timed out waiting for pid file to appear"
 	sleep 1
 done
@@ -20,9 +23,9 @@ kill "$(cat ${pidfile})"
 notice "killed daemon"
 
 # wait for the pid file to vanish
-limit=20
+elapsed=0
 while [ -s "${pidfile}" ] ; do
-	[ $((elapsed+=1)) -lt $limit ] ||
+	[ $((elapsed+=1)) -le "${timeout}" ] ||
 		fail "timed out waiting for pid file to vanish"
 	sleep 1
 done

--- a/t/test-pidfile.sh
+++ b/t/test-pidfile.sh
@@ -13,7 +13,7 @@ timeout=10
 elapsed=0
 while [ ! -s "${pidfile}" ] ; do
 	[ $((elapsed+=1)) -le "${timeout}" ] ||
-		fail "timed out waiting for pid file to appear"
+		fail_test "timed out waiting for pid file to appear"
 	sleep 1
 done
 notice "pid file appeared after $elapsed seconds"
@@ -21,7 +21,7 @@ notice "pid file appeared after $elapsed seconds"
 # kill tsdfx
 pid=$(cat "${pidfile}")
 expr "${pid}" : "^[1-9][0-9]*$" >/dev/null ||
-	fail "unexpected contents in pid file"
+	fail_test "unexpected contents in pid file"
 kill "${pid}"
 notice "killed daemon"
 
@@ -29,7 +29,7 @@ notice "killed daemon"
 elapsed=0
 while [ -s "${pidfile}" ] ; do
 	[ $((elapsed+=1)) -le "${timeout}" ] ||
-		fail "timed out waiting for pid file to vanish"
+		fail_test "timed out waiting for pid file to vanish"
 	sleep 1
 done
 notice "pid file vanished after $elapsed seconds"

--- a/t/test-pidfile.sh
+++ b/t/test-pidfile.sh
@@ -19,7 +19,10 @@ done
 notice "pid file appeared after $elapsed seconds"
 
 # kill tsdfx
-kill "$(cat ${pidfile})"
+pid=$(cat "${pidfile}")
+expr "${pid}" : "^[1-9][0-9]*$" >/dev/null ||
+	fail "unexpected contents in pid file"
+kill "${pid}"
 notice "killed daemon"
 
 # wait for the pid file to vanish

--- a/t/test-scanner-boundary.sh
+++ b/t/test-scanner-boundary.sh
@@ -46,7 +46,7 @@ while read fn ; do
 done < ${list}
 
 if [ $missing -gt 0 -o $invalid -gt 0 ] ; then
-	fail "$missing missing, $invalid invalid"
+	fail_test "$missing missing, $invalid invalid"
 fi
 
 cleanup_test

--- a/t/test-simplecopy.sh
+++ b/t/test-simplecopy.sh
@@ -24,27 +24,27 @@ run_daemon -1
 
 for good in test1 test2 ; do
 	if [ ! -e "${dstdir}/${good}" ] ; then
-		fail "missing: ${dstdir}/${good}"
+		fail_test "missing: ${dstdir}/${good}"
 	elif ! cmp -s "${srcdir}/${good}" "${dstdir}/${good}" ; then
-		fail "incorrect: ${dstdir}/${good}"
+		fail_test "incorrect: ${dstdir}/${good}"
 	fi
 done
 
 for bad in "test (2).txt" ; do
 	if [ -e "${bad}" ] ; then
-		fail "should not exist: ${bad}"
+		fail_test "should not exist: ${bad}"
 	fi
 done
 
 md5end=$(cd ${dstdir}; md5sum ${randomsize}krandom)
 if [ "$md5start" != "$md5end" ]; then
-    fail "${randomsize}krandom file changed from source to destination"
+    fail_test "${randomsize}krandom file changed from source to destination"
 fi
 
 # Make sure failed copy of "test (2).txt" and others are reported as
 # errors in destination directory.
 if [ ! -e "${dstdir}/tsdfx-error.log" ] ; then
-    fail "missing ${dstdir}/tsdfx-error.log"
+    fail_test "missing ${dstdir}/tsdfx-error.log"
 fi
 
 cleanup_test

--- a/t/testsuite-common.sh.in
+++ b/t/testsuite-common.sh.in
@@ -13,25 +13,6 @@ notice() {
 	echo "NOTICE $@" >&2
 }
 
-fail() {
-	(
-		[ -f "${pidfile}" ] && kill $(cat "${pidfile}")
-		echo "FAIL $@"
-		echo "last lines in log file:"
-		echo
-		tail -30 $logfile
-		echo
-		echo "source directory:"
-		echo
-		(cd "${tstdir}" && find src) | sort
-		echo
-		echo "dst directory:"
-		echo
-		(cd "${tstdir}" && find dst) | sort
-	) >&2
-	exit 1
-}
-
 setup_test() {
 	set -e
 
@@ -91,19 +72,48 @@ run_daemon() {
 	x "${tsdfx}" -v -l "${logfile}" -m "${mapfile}" -p "${pidfile}" "$@"
 }
 
-cleanup_test() {
+kill_daemon() {
+	[ -f "${pidfile}" ] || return 0
 	timeout=10
 	elapsed=0
-	if [ -f "${pidfile}" ] ; then
-		pid=$(cat "${pidfile}")
-		kill "${pid}" >/dev/null 2>&1
-		while kill -0 "${pid}" >/dev/null 2>&1 ; do
-			[ $((elapsed+=1)) -le "${timeout}" ] ||
-				fail "timed out waiting for tsdfx to stop"
-			sleep 1
-		done
-		notice "tsdfx stopped after ${elapsed} seconds"
+	pid=$(cat "${pidfile}")
+	if ! expr "${pid}" : "^[1-9][0-9]*$" >/dev/null ; then
+		echo "invalid pid in ${pidfile}" >&2
+		rm -f "${pidfile}"
+		return 1
 	fi
+	kill "${pid}" >/dev/null 2>&1 || return 0
+	while kill -0 "${pid}" >/dev/null 2>&1 ; do
+		if [ $((elapsed+=1)) -gt "${timeout}" ] ; then
+			echo "timed out waiting for tsdfx to stop" >&2
+			return 1
+		fi
+		sleep 1
+	done
+	notice "tsdfx stopped after ${elapsed} seconds"
+}
+
+fail() {
+	(
+		kill_daemon
+		echo "FAIL $@"
+		echo "last lines in log file:"
+		echo
+		tail -30 $logfile
+		echo
+		echo "source directory:"
+		echo
+		(cd "${tstdir}" && find src) | sort
+		echo
+		echo "dst directory:"
+		echo
+		(cd "${tstdir}" && find dst) | sort
+	) >&2
+	exit 1
+}
+
+cleanup_test() {
+	kill_daemon
 	chmod -R u+rwX "${tstdir}"
 	rm -rf "${tstdir}"
 }

--- a/t/testsuite-common.sh.in
+++ b/t/testsuite-common.sh.in
@@ -49,7 +49,7 @@ set_blocksize() {
 		elif [ -d "$1" ] ; then
 			bsfile="$1/bsfile"
 		else
-			fail "can't determine block size of $1"
+			fail_test "can't determine block size of $1"
 		fi
 		dd if=/dev/zero of="${bsfile}" bs=1048576 count=1
 	fi
@@ -61,7 +61,7 @@ set_blocksize() {
 		rm "${bsfile}"
 	fi
 	expr "${blocksize}" : '^[1-9][0-9]*$' >/dev/null || \
-	    fail "Unable to determine filesystem block size"
+	    fail_test "Unable to determine filesystem block size"
 	notice "Using ${blocksize}-byte blocks"
 }
 
@@ -93,7 +93,7 @@ kill_daemon() {
 	notice "tsdfx stopped after ${elapsed} seconds"
 }
 
-fail() {
+fail_test() {
 	(
 		kill_daemon
 		echo "FAIL $@"


### PR DESCRIPTION
The most important change is that the code used to kill the daemon at the end of the test has been split off into a more robust `kill_daemon()` function which is used by both paths (success and failure).
