### PR TITLE
Improve check for available space

### DIFF
--- a/bin/tsdfx/copy.c
+++ b/bin/tsdfx/copy.c
@@ -33,12 +33,6 @@
 
 #include <sys/stat.h>
 
-#if HAVE_SYS_STATVFS_H
-#include <sys/statvfs.h>
-#else
-#undef HAVE_STATVFS
-#endif
-
 #include <errno.h>
 #include <limits.h>
 #include <pwd.h>
@@ -346,9 +340,6 @@ int
 tsdfx_copy_wrap(const char *srcdir, const char *dstdir, const char *path)
 {
 	char srcpath[PATH_MAX], dstpath[PATH_MAX];
-#if HAVE_STATVFS
-	struct statvfs st;
-#endif
 	struct stat srcst, dstst;
 	mode_t mode;
 
@@ -420,16 +411,6 @@ tsdfx_copy_wrap(const char *srcdir, const char *dstdir, const char *path)
 	} else {
 		memset(&dstst, 0, sizeof dstst);
 	}
-
-#if HAVE_STATVFS
-	/* check for available space */
-	if (!S_ISDIR(srcst.st_mode) &&
-	    srcst.st_size > dstst.st_size && statvfs(dstdir, &st) == 0 &&
-	    (off_t)(st.f_bavail * st.f_bsize) < srcst.st_size - dstst.st_size) {
-		errno = EAGAIN;
-		return (-1);
-	}
-#endif
 
 	/* create task */
 	tsdfx_copy_new(srcpath, dstpath);


### PR DESCRIPTION
The code to check whether there is sufficient space to copy a file was duplicated in `tsdfx_copy_wrap()` and in the copier itself.  This means that it runs twice in the common case (first check succeeds, copy task starts, second check succeeds) and once in the rare case (first check fails, copy task is abandoned), all for the sake of saving a `fork()` / `execve()` once in a great while.  By removing the version in `tsdfx_copy_wrap()`, we ensure that the check only runs once per copy task, and allow the lack of space to be reported as a user error.

While there, make that code slightly more readable and improve the message that is logged when we're out of space.
