### PR TITLE
Enable additional warnings

### DIFF
--- a/bin/tsdfx/copy.c
+++ b/bin/tsdfx/copy.c
@@ -321,7 +321,7 @@ tsdfx_copy_child(void *ud)
 	ASSERTF((size_t)argc < sizeof argv / sizeof argv[0],
 	    "argv overflowed: %d > %z", argc, sizeof argv / sizeof argv[0]);
 	/* XXX should clean the environment */
-	execv(tsdfx_copier, (char *const *)argv);
+	execv(tsdfx_copier, (char *const *)(uintptr_t)argv);
 	ERROR("failed to execute copier process");
 }
 

--- a/bin/tsdfx/map.c
+++ b/bin/tsdfx/map.c
@@ -62,9 +62,9 @@ struct tsdfx_map {
 	struct tsdfx_recentlog *errlog;
 };
 
-static struct tsdfx_map **map;
-static size_t map_sz;
-static int map_len;
+static struct tsdfx_map **tsdfx_map;
+static size_t tsdfx_map_sz;
+static int tsdfx_map_len;
 
 /*
  * Validate a path
@@ -274,15 +274,15 @@ tsdfx_map_reload(const char *fn)
 	/* first, create new tasks */
 	i = j = 0;
 	while (j < newmap_len) {
-		res = (i < map_len) ?
-		    strcmp(map[i]->name, newmap[j]->name) : 1;
+		res = (i < tsdfx_map_len) ?
+		    strcmp(tsdfx_map[i]->name, newmap[j]->name) : 1;
 		if (res == 0) {
 			/* unchanged task */
-			VERBOSE("keeping %s", map[i]->name);
+			VERBOSE("keeping %s", tsdfx_map[i]->name);
 			++i, ++j;
 		} else if (res < 0) {
 			/* deleted task */
-			VERBOSE("dropping %s", map[i]->name);
+			VERBOSE("dropping %s", tsdfx_map[i]->name);
 			++i;
 		} else if (res > 0) {
 			/* new task */
@@ -298,20 +298,20 @@ tsdfx_map_reload(const char *fn)
 	}
 	/* copy unchanged tasks */
 	i = j = 0;
-	while (i < map_len) {
+	while (i < tsdfx_map_len) {
 		res = (j < newmap_len) ?
-		    strcmp(map[i]->name, newmap[j]->name) : -1;
+		    strcmp(tsdfx_map[i]->name, newmap[j]->name) : -1;
 		if (res == 0) {
 			/* unchanged task */
 			map_delete(newmap[j]);
-			newmap[j] = map[i];
-			map[i] = NULL;
+			newmap[j] = tsdfx_map[i];
+			tsdfx_map[i] = NULL;
 			tsdfx_scan_rush(newmap[j]->task);
 			++i, ++j;
 		} else if (res < 0) {
 			/* deleted task */
-			map_delete(map[i]);
-			map[i] = NULL;
+			map_delete(tsdfx_map[i]);
+			tsdfx_map[i] = NULL;
 			++i;
 		} else if (res > 0) {
 			/* new task */
@@ -321,15 +321,15 @@ tsdfx_map_reload(const char *fn)
 		}
 	}
 	/* the old map is now empty */
-	for (i = 0; i < map_len; ++i)
-		ASSERT(map[i] == NULL);
-	free(map);
-	map = newmap;
-	map_sz = newmap_sz;
-	map_len = newmap_len;
-	for (i = 0; i < map_len; ++i)
-		VERBOSE("map %s: %s -> %s", map[i]->name,
-		    map[i]->srcpath, map[i]->dstpath);
+	for (i = 0; i < tsdfx_map_len; ++i)
+		ASSERT(tsdfx_map[i] == NULL);
+	free(tsdfx_map);
+	tsdfx_map = newmap;
+	tsdfx_map_sz = newmap_sz;
+	tsdfx_map_len = newmap_len;
+	for (i = 0; i < tsdfx_map_len; ++i)
+		VERBOSE("map %s: %s -> %s", tsdfx_map[i]->name,
+		    tsdfx_map[i]->srcpath, tsdfx_map[i]->dstpath);
 	return (0);
 fail:
 	for (j = 0; i < newmap_len; ++j)
@@ -358,10 +358,10 @@ tsdfx_map_sched(void)
 {
 	int i;
 
-	for (i = 0; i < map_len; ++i) {
+	for (i = 0; i < tsdfx_map_len; ++i) {
 		/* nothing to do */
 	}
-	return (map_len);
+	return (tsdfx_map_len);
 }
 
 int
@@ -376,11 +376,11 @@ tsdfx_map_exit(void)
 {
 	int i;
 
-	for (i = 0; i < map_len; ++i) {
-		map_delete(map[i]);
-		map[i] = NULL;
+	for (i = 0; i < tsdfx_map_len; ++i) {
+		map_delete(tsdfx_map[i]);
+		tsdfx_map[i] = NULL;
 	}
-	free(map);
+	free(tsdfx_map);
 	tsdfx_recentlog_exit();
 	return (0);
 }

--- a/bin/tsdfx/scan.c
+++ b/bin/tsdfx/scan.c
@@ -320,7 +320,7 @@ tsdfx_scan_child(void *ud)
 	ASSERTF((size_t)argc < sizeof argv / sizeof argv[0],
 	    "argv overflowed: %d > %z", argc, sizeof argv / sizeof argv[0]);
 	/* XXX should clean the environment */
-	execv(tsdfx_scanner, (char * const *)argv);
+	execv(tsdfx_scanner, (char * const *)(uintptr_t)argv);
 	ERROR("failed to execute scanner process");
 	_exit(1);
 }

--- a/bin/tsdfx/tsdfx.h
+++ b/bin/tsdfx/tsdfx.h
@@ -40,9 +40,6 @@ int tsdfx_exit(void);
 extern int tsdfx_dryrun;
 extern int tsdfx_oneshot;
 
-extern int scan_running;
-extern int copy_running;
-
 extern const char *tsdfx_scanner;
 extern const char *tsdfx_copier;
 

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ AC_ARG_ENABLE([debug],
     AC_DEFINE(TSDFX_DEBUG, 1, [Turn debugging macros on]))
 AC_ARG_ENABLE([developer-warnings],
     AS_HELP_STRING([--enable-developer-warnings], [enable strict warnings (default is NO)]),
-    [CFLAGS="${CFLAGS} -Wall -Wextra"])
+    [CFLAGS="${CFLAGS} -Wall -Wextra -Wcast-qual -Wshadow"])
 AC_ARG_ENABLE([debugging-symbols],
     AS_HELP_STRING([--enable-debugging-symbols], [enable debugging symbols (default is NO)]),
     [CFLAGS="${CFLAGS} -O0 -g -fno-inline"])


### PR DESCRIPTION
This patch enables `-Wcast-qual` and `-Wshadow` and fixes the fallout. The latter option would have caught #69.
