### PR TITLE
Do not segfault when log file can not be opened.

### DIFF
--- a/bin/tsdfx/recentlog.c
+++ b/bin/tsdfx/recentlog.c
@@ -130,6 +130,11 @@ tsdfx_recentlog_log(struct tsdfx_recentlog *r, const char *msg)
 	WARNING("updating user visible log file");
 	/* FIXME write to logfile.new and rename */
 	fh = fopen(r->logfile, "w");
+	if (fh == NULL) {
+		ERROR("unable to write user errors to %s: %s",
+		      r->logfile, strerror(errno));
+		return;
+	}
 	cur = r->first;
 	while (cur != NULL) {
 		next = cur->next;


### PR DESCRIPTION
If the user visible log file can not be written to, report the problem to the system log and move on.  This fixes a crash bug in tsdfx (issue #86).
