### PR TITLE
Switch copier's effective GID to the file's group if possible.

### DIFF
--- a/bin/tsdfx/copy.c
+++ b/bin/tsdfx/copy.c
@@ -239,6 +239,11 @@ tsdfx_copy_new(const char *src, const char *dst)
 		VERBOSE("setuser(\"%s\") for %s", pw->pw_name, src);
 		if (tsd_task_setuser(t, pw->pw_name) != 0)
 			goto fail;
+		if (tsd_task_setegid(t, st.st_gid) != 0) {
+			WARNING("%s: owner %lu (%s) is not in group %lu", src,
+			    (unsigned long)st.st_uid, pw->pw_name,
+			    (unsigned long)st.st_gid);
+		}
 	} else {
 		VERBOSE("getpwuid(%lu) failed; setcred(%lu, %lu) for %s",
 		    (unsigned long)st.st_uid, (unsigned long)st.st_uid,

--- a/include/tsd/task.h
+++ b/include/tsd/task.h
@@ -108,6 +108,7 @@ struct tsd_tqueue {
 struct tsd_task *tsd_task_create(const char *, tsd_task_func *, void *);
 int tsd_task_setuser(struct tsd_task *, const char *);
 int tsd_task_setcred(struct tsd_task *, uid_t, gid_t *, int);
+int tsd_task_setegid(struct tsd_task *, gid_t);
 void tsd_task_destroy(struct tsd_task *);
 int tsd_task_start(struct tsd_task *);
 int tsd_task_stop(struct tsd_task *);


### PR DESCRIPTION
We introduce a new function in the task API, tsd_task_setegid(), which sets the tasks's effective GID (i.e. the first in the GID list) to the specified GID if and only if that GID is already the tasks's effective GID or one of the task's supplementary GIDs.

In tsdfx_copy_new(), if we choose tsd_task_setuser() instead of tsd_task_setcred() (i.e. if the source file's owner is known), we call tsd_task_setegid() with the source file's group.  If that fails, we emit a warning and allow the copying to proceed; the destination file's group will then be the user's primary file group as before.
