### PR TITLE
Reduse amount of logging during normal operation.

### DIFF
--- a/bin/tsdfx/recentlog.c
+++ b/bin/tsdfx/recentlog.c
@@ -127,7 +127,7 @@ tsdfx_recentlog_log(struct tsdfx_recentlog *r, const char *msg)
 	}
 
 	/* Next print log queue, while removing obsolete entries */
-	WARNING("updating user visible log file");
+	VERBOSE("updating user visible log file");
 	/* FIXME write to logfile.new and rename */
 	fh = fopen(r->logfile, "w");
 	if (fh == NULL) {

--- a/bin/tsdfx/scan.c
+++ b/bin/tsdfx/scan.c
@@ -531,7 +531,6 @@ tsdfx_scan_slurp_stderr(struct tsd_task *t)
 	ssize_t rlen;
 	char *buf, *end, *p, *q;
 
-	WARNING("Reading from stderr");
 	/* read as much as we can in the space we have left */
 	len = 0;
 	do {
@@ -561,7 +560,6 @@ tsdfx_scan_slurp_stderr(struct tsd_task *t)
 			break;
 		*q++ = '\0';
 		tsdfx_map_log(std->map, p);
-		ERROR("%s", p);
 	}
 
 	/*

--- a/libexec/copier/copier.c
+++ b/libexec/copier/copier.c
@@ -164,10 +164,10 @@ copyfile_open(const char *fn, int mode, int perm)
 		/* otherwise, create it */
 		if (isdir) {
 			if (mkdir(cf->name, perm) != 0) {
-				ERROR("%s: mkdir(): %s", cf->name, strerror(errno));
+				ERROR("%s: mkdir(..., %04o): %s", cf->name, perm, strerror(errno));
 				goto fail;
 			}
-			NOTICE("created directory %s", cf->name);
+			NOTICE("created directory %s (perm %04o)", cf->name, perm);
 			if ((cf->fd = open(fn, cf->mode)) < 0)
 				goto fail;
 		} else {

--- a/libexec/scanner/scanner.c
+++ b/libexec/scanner/scanner.c
@@ -369,7 +369,7 @@ main(int argc, char *argv[])
 	tsd_log_userlog(userlog);
 
 	if (getuid() == 0 || geteuid() == 0)
-		WARNING("running as root");
+		WARNING("running as root for %s", argv[0]);
 
 	if (tsdfx_scanner(argv[0]) != 0)
 		exit(1);


### PR DESCRIPTION
This get rid of some log messages that fill up the syslog when the service is running normally.
