### PR TITLE
Log how much time was spent scanning for files.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,9 @@ AC_CHECK_HEADERS([bsd/stdlib.h bsd/unistd.h])
 AC_SEARCH_LIBS([setproctitle], [bsd])
 AC_CHECK_FUNCS([setproctitle_init setproctitle])
 
+AC_SEARCH_LIBS([clock_gettime], [rt])
+AC_CHECK_FUNCS([clock_gettime])
+
 # hole detection
 AC_CHECK_DECLS([SEEK_HOLE])
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -6,7 +6,8 @@ TESTS = \
 	test-pidfile.sh \
 	test-purgesource.sh \
 	test-scanner-boundary.sh \
-	test-simplecopy.sh
+	test-simplecopy.sh \
+	test-timing.sh
 
 EXTRA_DIST = \
 	$(TESTS) \

--- a/t/test-timing.sh
+++ b/t/test-timing.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+. $(dirname $0)/testsuite-common.sh
+
+setup_test
+
+echo test1 > "${srcdir}/test1"
+echo test2 > "${srcdir}/test2"
+
+# the below does not work - d is created in dstdir,
+# but test3 is not copied because of permission error
+# mkdir ${srcdir}/d
+# echo test3 > "${srcdir}/d/test3"
+
+run_daemon
+
+# Timeout for various operations
+timeout=10
+
+# Wait for the first scan to complete
+elapsed=0
+while ! grep -q tsdfx_scan_stop "${logfile}" ; do
+	[ $((elapsed+=1)) -le "${timeout}" ] || 
+	    fail_test "timed out waiting for first scan"
+	sleep 1
+done
+
+if ! grep -q 'scanner stated 2 dir entries' "${logfile}" ; then
+        fail_test "timing tests failed - unexpected number of stated files."
+fi
+
+cleanup_test


### PR DESCRIPTION
Based on a patch from Marcin Krotkiewski and input from Dag-Erling
Smørgrav in pull request #95, rewritten to avoid global variables and
to use clock_gettime(CLOCK_MONOTONIC) directly instead of via library
function.
