### PR TITLE
Correct file/directory counter in scanner.

### DIFF
--- a/libexec/scanner/scanner.c
+++ b/libexec/scanner/scanner.c
@@ -314,7 +314,7 @@ int
 tsdfx_scanner(const char *path)
 {
 	struct scan_entry *se;
-	int processed, serrno;
+	int processed, subprocessed, serrno;
 	struct timespec timer_end, timer_start;
 
 	processed = 0;
@@ -325,8 +325,8 @@ tsdfx_scanner(const char *path)
 	clock_gettime(CLOCK_MONOTONIC, &timer_start);
 
 	while ((se = tsdfx_scan_next()) != NULL) {
-		processed = tsdfx_scan_process_directory(se->path);
-		if (processed == -1) {
+		subprocessed = tsdfx_scan_process_directory(se->path);
+		if (subprocessed == -1) {
 			serrno = errno;
 			tsdfx_scan_free(se);
 			tsdfx_scan_cleanup();
@@ -335,6 +335,7 @@ tsdfx_scanner(const char *path)
 			NOTICE("FAILED scanning directory '%s', measured time: %.3lf s", se->path, ELAPSED(timer_start, timer_end));
 			return (-1);
 		}
+		processed += subprocessed;
 	}
 	clock_gettime(CLOCK_MONOTONIC, &timer_end);
 	ASSERT(scan_todo == NULL && scan_tail == NULL);

--- a/t/test-timing.sh
+++ b/t/test-timing.sh
@@ -6,6 +6,10 @@ setup_test
 
 echo test1 > "${srcdir}/test1"
 echo test2 > "${srcdir}/test2"
+mkdir "${srcdir}/subdir1"
+echo test3 > "${srcdir}/subdir1/test3"
+mkdir "${srcdir}/subdir2"
+echo test4 > "${srcdir}/subdir2/test4"
 
 # the below does not work - d is created in dstdir,
 # but test3 is not copied because of permission error
@@ -25,7 +29,7 @@ while ! grep -q tsdfx_scan_stop "${logfile}" ; do
 	sleep 1
 done
 
-if ! grep -q 'scanner stated 2 dir entries' "${logfile}" ; then
+if ! grep -q 'scanner stated 6 dir entries' "${logfile}" ; then
         fail_test "timing tests failed - unexpected number of stated files."
 fi
 


### PR DESCRIPTION
Make sure to summarize the count from all subdirectories, not only the last one.
Extend test-timing.sh script to include subdirectories when testing.
