### PR TITLE
Rewrite scan collector to measure count and duration in master process.

### DIFF
--- a/libexec/scanner/scanner.c
+++ b/libexec/scanner/scanner.c
@@ -332,14 +332,14 @@ tsdfx_scanner(const char *path)
 			tsdfx_scan_cleanup();
 			errno = serrno;
 			clock_gettime(CLOCK_MONOTONIC, &timer_end);
-			NOTICE("FAILED scanning directory '%s', measured time: %.3lf s", se->path, ELAPSED(timer_start, timer_end));
+			VERBOSE("FAILED scanning directory '%s', measured time: %.3lf s", se->path, ELAPSED(timer_start, timer_end));
 			return (-1);
 		}
 		processed += subprocessed;
 	}
 	clock_gettime(CLOCK_MONOTONIC, &timer_end);
 	ASSERT(scan_todo == NULL && scan_tail == NULL);
-	NOTICE("scanner stated %li dir entries, measured time: %.3lf s",
+	VERBOSE("found %li dir entries, measured time: %.3lf s",
 	       processed, path, ELAPSED(timer_start, timer_end));
 	tsdfx_scan_cleanup();
 	return (0);

--- a/t/test-timing.sh
+++ b/t/test-timing.sh
@@ -29,7 +29,7 @@ while ! grep -q tsdfx_scan_stop "${logfile}" ; do
 	sleep 1
 done
 
-if ! grep -q 'scanner stated 6 dir entries' "${logfile}" ; then
+if ! grep -q 'found 6 dir entries' "${logfile}" ; then
         fail_test "timing tests failed - unexpected number of stated files."
 fi
 


### PR DESCRIPTION
This give a more relevant measurement on the time spent scanning for files.

Lower the log level for the equivalent measurement in the scanner subprocess
from NOTICE to VERBOSE, to only log one such measurement by default.

Rewrite both log messages to talk about files found, not files stat()-ed, as
the item counted is directory entries, not stat()s.
