### PR TITLE
Use correct mode when opening a new directory.

### DIFF
--- a/libexec/copier/copier.c
+++ b/libexec/copier/copier.c
@@ -168,7 +168,14 @@ copyfile_open(const char *fn, int mode, int perm)
 				goto fail;
 			}
 			NOTICE("created directory %s (perm %04o)", cf->name, perm);
-			if ((cf->fd = open(fn, cf->mode)) < 0)
+			/*
+			 * open() on Linux reject directories with
+			 * O_CREAT, even if the directory already
+			 * exist.
+			 */
+			mode = mode & ~O_CREAT;
+
+			if ((cf->fd = open(fn, mode)) < 0)
 				goto fail;
 		} else {
 			if ((cf->fd = open(cf->name, mode, perm)) < 0) {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,4 +1,5 @@
 TESTS = \
+	test-copier.sh \
 	test-copy-classes.sh \
 	test-file-hole.sh \
 	test-inaccessible-dir.sh \

--- a/t/test-copier.sh
+++ b/t/test-copier.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Verify the copier can copy a directory correctly on one run.  This
+# used to take at least two runs, one to run mkdir and the other to
+# run chmod.
+
+. $(dirname $0)/testsuite-common.sh
+
+setup_test
+
+
+mkdir -m 755 "${srcdir}/d"
+if ! $copier "${srcdir}/d/" "${dstdir}/d/" > ${logfile} ; then
+    fail_test "copier returned failure when copying directories"
+fi
+
+dstmode=$(stat -c %a "${dstdir}/d")
+if [ 755 != "$dstmode" ] ; then
+    fail_test "directory created with wrong access mode"
+fi
+
+cleanup_test

--- a/t/test-copier.sh
+++ b/t/test-copier.sh
@@ -8,14 +8,13 @@
 
 setup_test
 
-
 mkdir -m 755 "${srcdir}/d"
 if ! $copier "${srcdir}/d/" "${dstdir}/d/" > ${logfile} ; then
     fail_test "copier returned failure when copying directories"
 fi
 
-dstmode=$(stat -c %a "${dstdir}/d")
-if [ 755 != "$dstmode" ] ; then
+dstmode=$(stat -f%p "${dstdir}/d" || stat -c%a "${dstdir}/d") 2>/dev/null
+if [ 755 != $((dstmode % 1000)) ] ; then
     fail_test "directory created with wrong access mode"
 fi
 


### PR DESCRIPTION
The open() call after mkdir() would always fail with EISDIR on Linux,
because the mode used was the saved one, not the calculated one, and
because the mode included O_CREAT.  Change the code to remove
O_CREAT from the calculated one and use it instead.

Add O_DIRECTORY to make sure the open() fail if someone replaced the
directory with a file.

Add test script demonstrating the problem and verifying its fix.
