### PR TITLE
Abort scanning if there are more than 10000 files in a source directory.

### DIFF
--- a/libexec/scanner/tsdfx-scanner.8
+++ b/libexec/scanner/tsdfx-scanner.8
@@ -26,7 +26,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd December 18, 2015
+.Dd August 17, 2016
 .Dt TSDFX-SCANNER 8
 .Os
 .Sh NAME
@@ -36,6 +36,7 @@
 .Nm
 .Op Fl v
 .Op Fl l logspec
+.Op Fl m maxfiles
 .Ar Pa path
 .Sh DESCRIPTION
 The
@@ -57,6 +58,10 @@ to log to standard error,
 to log to
 .Xr syslog 8 ,
 or a file name.
+.It Fl m Ar maxfiles
+Set the maximum number of files to scan before exiting.  This ensure no scanner
+spend too much time scanning even if some user flood the input directory with files.
+Set to 0 (zero) to scan without any limit.  The default limit is 10.000 files.
 .It Fl v
 Verbose mode: log a large amount of information about the inner
 workings of


### PR DESCRIPTION
This make sure the service can not be overloaded by flodding one source
directory with files.  The number 10 000 is picked as such scan is fairly quick
while still being higher than what we commonly se in production.

Closes issue #109
