### PR TITLE
Fix build problem with newer glibc.

### DIFF
--- a/lib/libtsd/tsd_sha1.c
+++ b/lib/libtsd/tsd_sha1.c
@@ -37,6 +37,7 @@
 #endif
 
 #if HAVE_ENDIAN_H
+#define _DEFAULT_SOURCE
 #define _BSD_SOURCE
 #include <endian.h>
 #endif


### PR DESCRIPTION
Make sure to define _DEFAULT_SOURCE alongside _BSD_SOURCE, required to
build at least with glibc 2.23.

Closes issue #115.
