### PR TITLE
Raise scan limit from 10000 to 40000.

### DIFF
--- a/libexec/scanner/scanner.c
+++ b/libexec/scanner/scanner.c
@@ -51,7 +51,7 @@
 #include <tsd/strutil.h>
 #include <tsd/percent.h>
 
-static long maxfiles = 10000;
+static long maxfiles = 40000;
 
 struct scan_entry {
 	struct sbuf *path;


### PR DESCRIPTION
This reduce the chance of blocking a project with many form submissions from
importing any files.

Related to UiO RT #2317407.