### PR TITLE
Reduce purge period from 30 to 14 days.

### DIFF
--- a/bin/tsdfx/copy.c
+++ b/bin/tsdfx/copy.c
@@ -64,7 +64,7 @@ int tsdfx_dryrun = 0;
  * When source files are unmodified for this long, and already present
  * in destination directory, purge it from the source directory.
  */
-time_t tsdfx_copy_purgeperiod = 30 * 24 * 60 * 60; /* default is 30 days */
+time_t tsdfx_copy_purgeperiod = 14 * 24 * 60 * 60; /* default is 14 days */
 
 /*
  * Private data for a copy task

--- a/bin/tsdfx/main.c
+++ b/bin/tsdfx/main.c
@@ -60,7 +60,7 @@ usage(void)
 {
 
 	fprintf(stderr, "usage: tsdfx [-1nv] "
-	    "[-l logname] [-C copier] [-M maxfiles] [-p pidfile] [-S scanner] -m mapfile\n");
+	    "[-l logname] [-C copier] [-d purgetime ] [-M maxfiles] [-p pidfile] [-S scanner] -m mapfile\n");
 	exit(1);
 }
 

--- a/bin/tsdfx/tsdfx.8
+++ b/bin/tsdfx/tsdfx.8
@@ -36,6 +36,7 @@
 .Nm
 .Op Fl 1fhnv
 .Op Fl C Ar copier
+.Op Fl d Ar purgetime
 .Op Fl S Ar scanner
 .Op Fl l Ar logspec
 .Op Fl M Ar maxfiles
@@ -62,9 +63,12 @@ Path to the copier program.
 See
 .Xr tsdfx-copier 8 .
 .It Fl d Ar sec
-Set purge time limit.  Remove source files when they are copied to the
-destination and their mtime is more than sec in the past.  When sec is
-0, do not purge.  The default is 30 days.
+Set purge time limit in seconds.  Remove source files when they are
+copied to the destination and their mtime is more than
+.Va sec
+in the past.  When
+.Va sec
+is 0, do not purge.  The default is 14 days.
 .It Fl f
 Foreground mode: do not daemonize.
 .It Fl i Ar sec


### PR DESCRIPTION
If a file has been successfully transfered for 14 days, there is no
need to keep the original copy in the source directory.