### PR TITLE
Use same loop variable in each fail block.

### DIFF
--- a/bin/tsdfx/map.c
+++ b/bin/tsdfx/map.c
@@ -332,8 +332,8 @@ tsdfx_map_reload(const char *fn)
 		    tsdfx_map[i]->srcpath, tsdfx_map[i]->dstpath);
 	return (0);
 fail:
-	for (j = 0; i < newmap_len; ++j)
-		map_delete(newmap[j]);
+	for (i = 0; i < newmap_len; ++i)
+		map_delete(newmap[i]);
 	free(newmap);
 	return (-1);
 }


### PR DESCRIPTION
This fixes a build failure with clang, which discovered we were
modifying j while testing for i.